### PR TITLE
Fix `font-info` query format.

### DIFF
--- a/svg-lib.el
+++ b/svg-lib.el
@@ -222,7 +222,7 @@ and style elements ARGS."
 
          (txt-char-width  (window-font-width))
          (txt-char-height (window-font-height))
-         (font-info       (font-info (format "%s:%d" font-family font-size)))
+         (font-info       (font-info (format "%s-%d" font-family font-size)))
          (ascent          (aref font-info 8))
          (tag-char-width  (aref font-info 11))
          (tag-char-height (aref font-info 3))
@@ -276,7 +276,7 @@ and style elements ARGS."
          (txt-char-width  (window-font-width))
          (txt-char-height (window-font-height))
          
-         (font-info       (font-info (format "%s:%d" font-family font-size)))
+         (font-info       (font-info (format "%s-%d" font-family font-size)))
          (ascent          (aref font-info 8))
          (tag-char-width  (aref font-info 11))
          (tag-char-height (aref font-info 3))
@@ -347,7 +347,7 @@ and style elements ARGS."
          (txt-char-width  (window-font-width))
          (txt-char-height (window-font-height))
          
-         (font-info       (font-info (format "%s:%d" font-family font-size)))
+         (font-info       (font-info (format "%s-%d" font-family font-size)))
          (ascent          (aref font-info 8))
          (tag-char-width  (aref font-info 11))
          (tag-char-height (aref font-info 3))
@@ -510,7 +510,7 @@ and style elements ARGS."
          (box-width       (* width txt-char-width))
          (box-height      (* height txt-char-height))
 
-         (font-info       (font-info (format "%s:%d" font-family font-size)))
+         (font-info       (font-info (format "%s-%d" font-family font-size)))
          (ascent          (aref font-info 8))
          (tag-char-width  (aref font-info 11))
          (tag-char-height (aref font-info 3))


### PR DESCRIPTION
From emacs info section, info:emacs#Fonts, font size should be prepended
with `-`, not `:`. The latter is to specify key-value pair.

This commit fixes a bug with font size specification per each SVG image creation.