### PR TITLE
Better calculations for svg-lib-tag

### DIFF
--- a/svg-lib.el
+++ b/svg-lib.el
@@ -227,28 +227,44 @@ and style elements ARGS."
          (font-weight (plist-get style :font-weight))
 
          (txt-char-width  (window-font-width))
+         (txt-width       (* txt-char-width (length label)))
          (txt-char-height (window-font-height))
+
          (font-info       (font-info (format "%s-%d" font-family font-size)))
          (ascent          (aref font-info 8))
          (tag-char-width  (aref font-info 11))
+         (tag-txt-width   (* tag-char-width (length label)))
          ;; (tag-char-height (aref font-info 3))
-         (tag-width       (* (+ (length label) padding) txt-char-width))
-         (tag-height      (* txt-char-height height))
 
-         (svg-width       (+ tag-width (* margin txt-char-width)))
-         (svg-height      tag-height)
+         (total-width     (+ tag-txt-width stroke (* padding 2) (* margin 2)))
+         (svg-width       (if (= (mod total-width
+                                      txt-char-width)
+                                 0)
+                              total-width
+                            (* (+ (truncate (/ total-width
+                                               txt-char-width))
+                                  1)
+                               txt-char-width)))
+         (box-width       (- svg-width (* margin 2)))
+         (tag-width       (- box-width (if (>= stroke 0.25) stroke 0)))
 
-         (tag-x (/ (- svg-width tag-width) 2))
-         (text-x (+ tag-x (/ (- tag-width (* (length label) tag-char-width)) 2)))
-         (text-y ascent)
+         (box-x           margin)
+         (box-y           0)
+         (tag-x           (+ margin (/ stroke 2.0)))
+         (tag-y           (/ stroke 2.0))
+
+         (box-height      (* txt-char-height height))
+         (tag-height      (- box-height stroke))
+         (svg-height      box-height)
+         (text-x          (+ tag-x (/ (- tag-width (* (length label) tag-char-width)) 2)))
+         (text-y          ascent)
          
          (svg (svg-create svg-width svg-height)))
 
     (if (>= stroke 0.25)
-        (svg-rectangle svg tag-x 0 tag-width tag-height
+        (svg-rectangle svg box-x box-y box-width box-height
                            :fill foreground :rx radius))
-    (svg-rectangle svg (+ tag-x (/ stroke 2.0)) (/ stroke 2.0)
-                       (- tag-width stroke) (- tag-height stroke)
+    (svg-rectangle svg tag-x tag-y tag-width tag-height
                        :fill background :rx (- radius (/ stroke 2.0)))
     (svg-text svg label
               :font-family font-family :font-weight font-weight  :font-size font-size

--- a/svg-lib.el
+++ b/svg-lib.el
@@ -253,9 +253,9 @@ and style elements ARGS."
          (tag-x           (+ margin (/ stroke 2.0)))
          (tag-y           (/ stroke 2.0))
 
-         (box-height      (* txt-char-height height))
+         (svg-height      (* txt-char-height height))
+         (box-height      svg-height)
          (tag-height      (- box-height stroke))
-         (svg-height      box-height)
          (text-x          (+ tag-x (/ (- tag-width (* (length label) tag-char-width)) 2)))
          (text-y          ascent)
          

--- a/svg-lib.el
+++ b/svg-lib.el
@@ -249,15 +249,15 @@ and style elements ARGS."
          (tag-width       (- box-width (if (>= stroke 0.25) stroke 0)))
 
          (box-x           margin)
-         (box-y           0)
+         (box-y           1)
          (tag-x           (+ margin (/ stroke 2.0)))
-         (tag-y           (/ stroke 2.0))
+         (tag-y           (+ box-y (/ stroke 2.0)))
 
          (svg-height      (* txt-char-height height))
-         (box-height      svg-height)
+         (box-height      (- svg-height box-y))
          (tag-height      (- box-height stroke))
          (text-x          (+ tag-x (/ (- tag-width (* (length label) tag-char-width)) 2)))
-         (text-y          ascent)
+         (text-y          (+ ascent box-y))
          
          (svg (svg-create svg-width svg-height)))
 


### PR DESCRIPTION
After some testing and what happened in rougier/svg-tag-mode/pull/14 I decided to continue my work in this repo, since it is like the 'updated' version of the other one. I have been able to make the tags have the same width as the rest of characters on the frame, something that (at least to me) didn't work.

I also have fixed that tags in different lines, one above another, had their border next to each other without any space in between.

WIP: Making the text stay at the center, actual code:
```emacs-lisp
(text-x (+ tag-x
           padding
           (/ (- tag-width
                 (* padding 2)
                 tag-txt-width)
              2.0)))
```

But it doesn't work as expected, it seems like the total width of the characters inside the tag is strangely big, take a look at the next output of a tag's svg-width and it's tag-txt-width:
```
80 svg-width, 70 tag-txt-width
```
And it looks like this:
![Sat-18-Dec-2021_21-41-42](https://user-images.githubusercontent.com/68018085/146654982-46f1137f-0341-4445-a52f-84214529f166.png)
Feels like it should be way less, like 50 instead of 70, because if I understood correctly `tag-char-width` is the width of the characters **inside** the tag.
Edit: Actually, by measuring the image, it seems like the text is actually 48px (like 2/3 of the actual width it tells)

PS: My font is Iosevka Term, height 120