### PR TITLE
svg-lib-tag: redefine font-size with font-info val

### DIFF
--- a/svg-lib.el
+++ b/svg-lib.el
@@ -252,6 +252,7 @@ and style elements ARGS."
                               (+ txt-char-height line-spacing)
                           txt-char-height))
          (font-info       (font-info (format "%s-%d" font-family font-size)))
+         (font-size       (aref font-info 2)) ;; redefine font-size
          (ascent          (aref font-info 8))
          (tag-char-width  (aref font-info 11))
          ;; (tag-char-height (aref font-info 3))


### PR DESCRIPTION
It's unclear to the author of this commit why it makes difference,
however it fixes a problem on the Ubuntu system with IBM Plex Mono font.

See #14