### PR TITLE
Silence byte compilation warnings

### DIFF
--- a/svg-lib.el
+++ b/svg-lib.el
@@ -193,7 +193,7 @@ If COLOR-NAME is unknown to Emacs, then return COLOR-NAME as-is."
   
   (let* ((default svg-lib-style-default)
          (base (or base default))
-         (keys (cl-loop for (key value) on default by 'cddr
+         (keys (cl-loop for (key _value) on default by 'cddr
                         collect key))
          (style '()))
 

--- a/svg-lib.el
+++ b/svg-lib.el
@@ -337,7 +337,7 @@ and style elements ARGS."
          (x1              (+ cx (* iradius (cos angle1))))
          (y1              (+ cy (* iradius (sin angle1))))
 
-         (large-arc       (if (>= (- angle1 angle0) pi) t nil))
+         (large-arc       (if (>= (- angle1 angle0) float-pi) t nil))
          (svg (svg-create svg-width svg-height)))
 
     (if (>= stroke 0.25)
@@ -345,7 +345,7 @@ and style elements ARGS."
 
     (svg-circle svg cx cy (- radius (/ stroke 2.0)) :fill background)
 
-    (if (>= (- angle1 angle0) (* pi 2))
+    (if (>= (- angle1 angle0) (* float-pi 2))
         (svg-circle svg cx cy iradius :fill foreground)
       (svg-path svg `((moveto ((,cx . ,cy)))
                     (lineto ((,x0 . ,y0)))


### PR DESCRIPTION
These changes silence a couple of byte compilation warnings, namely:

- that the `pi` variable has been obsolete since Emacs 23, and
- that the lexical variable `value` is unused.

For the first warning `pi` is changed to `float-pi` and for the second `value` is changed to `_value` to indicate to the compiler that its supposed to be unused.