### PR TITLE
Bootstrap icon url has changed, fixes #24

### DIFF
--- a/svg-lib.el
+++ b/svg-lib.el
@@ -108,7 +108,7 @@
 ;; ---------------------------------------------------------------------
 (defcustom  svg-lib-icon-collections
   '(("bootstrap" .
-     "https://icons.getbootstrap.com/icons/%s.svg")
+     "https://icons.getbootstrap.com/assets/icons/%s.svg")
     ("simple" .
      "https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/%s.svg")
     ("material" .


### PR DESCRIPTION
As mentioned in https://github.com/rougier/svg-lib/issues/24, the bootstrap icon url now produces 404's.

Old url https://icons.getbootstrap.com/icons/journal-code.svg
New url https://icons.getbootstrap.com/assets/icons/journal-code.svg