### PR TITLE
Move button mode to the top so icons will show properly

### DIFF
--- a/svg-lib-demo.el
+++ b/svg-lib-demo.el
@@ -21,6 +21,7 @@
 :; Each line should insert some svg objets into the current buffer.
 
 (require 'svg-lib)
+(svg-lib-button-mode 1)
 
 (dotimes (i 5)
   (insert-image (svg-lib-tag "TODO" nil
@@ -65,7 +66,6 @@
 (insert-image (svg-lib-date nil nil :font-family "Roboto" :radius 5
                                     :foreground "#673AB7"))
  
-(svg-lib-button-mode 1)
 (insert (svg-lib-button "[check-bold] OK"
                         (lambda () (interactive) (message "OK"))))
 


### PR DESCRIPTION
In issue #38 I ran into the issue where none of my icons were being inserted after going through most of the demo. Though after running `(svg-lib-button-mode 1)`, I was able to rerun those examples and get all the icons showing. I attached a before/after screenshots to the issue. 