### PR TITLE
Fix bug reading stroke width from existing face

### DIFF
--- a/svg-lib.el
+++ b/svg-lib.el
@@ -309,7 +309,7 @@ If COLOR-NAME is unknown to Emacs, then return COLOR-NAME as-is."
          (stroke      (or (plist-get (face-attribute face :box) ':line-width) nil))
          (style       `(:background ,background
                         :foreground ,foreground
-                        ,@(when stroke `(:stroke stroke))
+                        ,@(when stroke `(:stroke ,stroke))
                         :font-family ,font-family
                         :font-size ,font-size
                         :font-weight ,font-weight))


### PR DESCRIPTION
When svg-lib-style-from-face runs on a face with a box line-width, the resulting stroke is "stroke" instead of the number